### PR TITLE
Helm keystore feature

### DIFF
--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,15 +1,38 @@
+{{- $configMapName := printf "%s-config" (include "PolyNSI.fullname" .) }}
+{{- $existingConfigMap := "" }}
+{{- if .Values.config.checkExistence }}
+{{- $existingConfigMap = lookup "v1" "ConfigMap" .Release.Namespace $configMapName }}
+{{- end }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-config" (include "PolyNSI.fullname" .) }}
+  name: {{ $configMapName }}
 #  namespace: {{ .Release.Namespace }}
+{{- if and .Values.config.checkExistence $existingConfigMap }}
+# Preserve existing ConfigMap data
+{{- if $existingConfigMap.data }}
+data:
+{{- range $key, $value := $existingConfigMap.data }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- if $existingConfigMap.binaryData }}
+binaryData:
+{{- range $key, $value := $existingConfigMap.binaryData }}
+  {{ $key }}: {{ $value }}
+{{- end }}
+{{- end }}
+{{- else }}
+# Create new ConfigMap data from values
 {{- if .Values.config.filesGlob }}
 binaryData:
 {{- range $path, $_ :=  .Files.Glob  .Values.config.filesGlob }}
-{{ $path | base | indent 2 }}: |-
+  {{ $path | base }}: |-
 {{ $.Files.Get $path | b64enc | indent 4 }}
-{{ end }}
-{{ else if .Values.config.inline }}
+{{- end }}
+{{- else if .Values.config.inline }}
 data:
-{{.Values.config.inline | indent 2}}
-{{ end }}
+{{ .Values.config.inline | indent 2 }}
+{{- end }}
+{{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -68,8 +68,8 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
               subPath: {{ .Values.persistence.subPath }}
           {{- end }}
-            - name: config
-              mountPath: "/usr/local/etc/polynsi"
+            - name: combined-config
+              mountPath: /usr/local/etc/polynsi/
               readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -84,9 +84,25 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: config
-          configMap:
-            name: {{ printf "%s-config" (include "PolyNSI.fullname" .) }}
+        - name: combined-config
+          projected:
+            sources:
+              - configMap:
+                    name: {{ printf "%s-config" (include "PolyNSI.fullname" .) }}
+            {{- if .Values.keystore.enabled }}
+              - secret:
+                  name: {{ .Values.keystore.secretName }}
+                  items:
+                    - key: {{ .Values.keystore.key }}
+                      path: polynsi-keystore.jks
+            {{- end }}
+            {{- if .Values.truststore.enabled }}
+              - secret:
+                  name: {{ .Values.truststore.secretName }}
+                  items:
+                    - key: {{ .Values.truststore.key }}
+                      path: polynsi-truststore.jks
+      {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -98,6 +98,7 @@ truststore:
   key: truststore.jks
 
 config:
+  checkExistence: false  # Set to true to not overwrite existing configmap.
   # either read config files from folder or use inline data, filesGlob takes precedence over inline.
   #filesGlob: "config/*"
   inline: |-

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -87,6 +87,16 @@ persistence:
     - ReadWriteOnce
   size: 1Gi
 
+keystore:
+  enabled: false
+  secretName: polynsi-keystore
+  key: keystore.jks
+
+truststore:
+  enabled: false
+  secretName: polynsi-truststore
+  key: truststore.jks
+
 config:
   # either read config files from folder or use inline data, filesGlob takes precedence over inline.
   #filesGlob: "config/*"


### PR DESCRIPTION
Adds optional keystore to helm chart.
This enables the use of a keystore provisioned externally or by cert-manager.
I moved the file locations so it was easier to mount Secrets without overwriting data in parent directories.
The certificate manifest is not included here but could be. I'm using the generated cert for multiple purposes so it doesn't necessarily make sense to put it in this repo (but I could add it as optional). The cert is used for both PolyNSI and SuPA Ingress as well as the PolyNSI keystore.
I also added a similar feature for a truststore is needed.

Adds feature to keep manual changes to configmap.
If enabled, the configmap resource is not overwritten during a helm upgrade and manual changes are preserved.