### PR TITLE
Add HTTPRoute support to Helm chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/httproute.yaml
+++ b/chart/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "PolyNSI.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "PolyNSI.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+      {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else }}
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -68,6 +68,39 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Expose the service via gateway-api HTTPRoute instead of an Ingress.
+# Requires Gateway API CRDs and a suitable controller (e.g. Envoy Gateway).
+# Each rule may define its own backendRefs; when omitted the rule falls back
+# to this chart's own service on service.port.
+httpRoute:
+  enabled: false
+  annotations: {}
+  parentRefs:
+    - name: gateway
+      sectionName: http
+  hostnames:
+    - chart-example.local
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /soap
+      backendRefs:
+        - name: polynsi
+          port: 80
+          weight: 1
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /discovery
+        - path:
+            type: PathPrefix
+            value: /topology
+      backendRefs:
+        - name: supa
+          port: 80
+          weight: 1
+
 # if you do not want to use ingress annotations to generate the Certificate manifest
 certificate:
   enabled: false


### PR DESCRIPTION
Adds helm template for HTTPRoute which can be used with the Gateway API instead of (nginx) ingresses. Placeholder variables are placed in values.yaml.